### PR TITLE
WIP: Feature: Add Animated SVG Throttle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 .AppleDouble
 .LSOverride
 
-# Icon must end with two 
+# Icon must end with two
 Icon
 # Thumbnails
 ._*
@@ -78,3 +78,5 @@ jspm_packages
 
 # Yarn Integrity file
 .yarn-integrity
+
+dist

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   },
   "dependencies": {
     "node-sass": "^4.7.2",
+    "rxjs": "^5.5.6",
     "sass-loader": "^6.0.6",
-    "vue": "^2.5.2"
+    "vue": "^2.5.2",
+    "vue-rx": "^5.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.2",

--- a/src/components/animatedicons/IconHeartFace.vue
+++ b/src/components/animatedicons/IconHeartFace.vue
@@ -1,9 +1,9 @@
 <template>
-  <svg 
-    @click="makeHeart"
-    xmlns="http://www.w3.org/2000/svg" 
-    width="100" 
-    height="100" 
+  <svg
+    v-stream:click="heartStream$"
+    xmlns="http://www.w3.org/2000/svg"
+    width="100"
+    height="100"
     viewBox="0 0 120 120"
     aria-labelledby="heartface"
     role="presentation"
@@ -53,6 +53,23 @@
 import { TweenMax, TimelineMax, Sine } from 'gsap'
 
 export default {
+  domStreams: ['heartStream$'], // vue-rx / RxJS Subject
+  subscriptions () { // vue-rx
+    return {
+      heartAnimation$: this.heartStream$
+        .filter(() => !this.locked)
+        .do(() => {
+          this.makeHeart()
+          // Lock the stream, do not fire anymore!
+          this.locked = true
+        })
+    }
+  },
+  data: () => {
+    return {
+      locked: false
+    }
+  },
   methods: {
     makeHeart() {
       TweenMax.set('#heartface', {
@@ -60,6 +77,9 @@ export default {
       })
 
       const tl = new TimelineMax()
+
+      // Unlock the stream after the timeline completes
+      tl.eventCallback('onComplete', () => this.locked = false)
 
       tl.add('start')
       tl.fromTo(

--- a/src/main.js
+++ b/src/main.js
@@ -1,9 +1,28 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
 import Vue from 'vue'
+
+// Bring what we need to from RxJS
+import { Observable } from 'rxjs/Observable'
+import { Subject } from 'rxjs/Subject'
+
+// Patch the Observable Prototype with only what we need
+import 'rxjs/add/observable/fromEvent'
+import 'rxjs/add/operator/do'
+import 'rxjs/add/operator/filter'
+
+// Bring in vue-rx for RxJS Vue bindings
+import VueRx from 'vue-rx'
+
 import App from './App'
 
 Vue.config.productionTip = false
+
+// Register vue-rx as a plugin
+Vue.use(VueRx, {
+  Observable,
+  Subject
+})
 
 /* eslint-disable no-new */
 new Vue({

--- a/yarn.lock
+++ b/yarn.lock
@@ -4606,6 +4606,12 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
+rxjs@^5.5.6:
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
+  dependencies:
+    symbol-observable "1.0.1"
+
 safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -5043,6 +5049,10 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
+
 tapable@^0.2.7:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
@@ -5348,6 +5358,10 @@ vue-loader@^13.3.0:
     vue-hot-reload-api "^2.2.0"
     vue-style-loader "^3.0.0"
     vue-template-es2015-compiler "^1.6.0"
+
+vue-rx@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/vue-rx/-/vue-rx-5.0.0.tgz#71ed02e68c5e04db9d3cb765f4454b619a75c32d"
 
 vue-style-loader@^3.0.0, vue-style-loader@^3.0.1:
   version "3.0.3"


### PR DESCRIPTION
Hey Sarah,

Thanks for sharing this out, it's very similar to how I like to work with SVGs in my Vue projects (I like to utilize [svg-sprite-loader](https://github.com/kisenka/svg-sprite-loader) and [svgo-loader](https://github.com/rpominov/svgo-loader)), and I like what you have going on here!

## Feature: Add RxJS Throttle on Animated SVGs
I noticed that the animations were breaking pretty quick after a few subsequent clicks. I'm on an RxJS + Vue kick, and I saw we could add a quick throttle here, utilizing RxJS and [vue-rx](https://github.com/vuejs/vue-rx).

Lemme know if you're down with adding something like this and I can add them to the other animations too, maybe compose it a bit differently so we wouldn't have to do so much boilerplate.