### PR TITLE
add class='align-middle' by default

### DIFF
--- a/src/components/IconBase.vue
+++ b/src/components/IconBase.vue
@@ -5,6 +5,7 @@
     viewBox="0 0 18 18" 
     :aria-labelledby="iconName" 
     role="presentation"
+    class='align-middle'
   >
     <title :id="iconName" lang="en">{{iconName}} icon</title>
     <g :fill="iconColor">


### PR DESCRIPTION
when icons are used next to text (next to a link, in a button etc), these look better if vertically aligned at the center of the text. 
Probably it would be helpful to have this alignment set by default. 
This kind of alignment is commonly requested (see for example, in another context: https://stackoverflow.com/questions/43759462/bootstrap-4-button-align-text-with-icon)